### PR TITLE
(fix) Ensure that added locations are fetched by `bhLocationSelect`

### DIFF
--- a/client/src/js/components/bhLocationSelect.js
+++ b/client/src/js/components/bhLocationSelect.js
@@ -14,7 +14,7 @@ angular.module('bhima.components')
   }
 });
 
-LocationSelectController.$inject =  [ 'LocationService', '$scope', '$timeout' ];
+LocationSelectController.$inject =  [ 'LocationService', '$rootScope', '$scope', '$timeout' ];
 
 /**
  * Location Select Controller
@@ -52,7 +52,7 @@ LocationSelectController.$inject =  [ 'LocationService', '$scope', '$timeout' ];
  * </bh-location-select>
  *
  */
-function LocationSelectController(Locations, $scope, $timeout) {
+function LocationSelectController(Locations, $rootScope, $scope, $timeout) {
   var vm = this;
 
   /** loading indicator */
@@ -111,7 +111,7 @@ function LocationSelectController(Locations, $scope, $timeout) {
   };
 
   function loadCountries() {
-    Locations.countries()
+    return Locations.countries()
     .then(function (countries) {
 
       // bind the countries to view
@@ -280,15 +280,31 @@ function LocationSelectController(Locations, $scope, $timeout) {
    */
   $scope.$watch('$ctrl.locationUuid', loadLocation);
 
+  // @TODO Temporary locations update fix - this should expose an API to be updated or
+  // should use bhConstants
+  $rootScope.$on('LOCATIONS_UPDATED', refreshData);
+
+  function refreshData() {
+    var cacheSector = angular.copy(vm.sector);
+    var cacheVillage = angular.copy(vm.village);
+
+    loadProvinces()
+    .then(function (results) {
+      return loadSectors();
+    })
+    .then(function (results) {
+      vm.sector = cacheSector;
+      return loadVillages();
+    })
+    .then(function () {
+      vm.village = cacheVillage;
+    });
+  }
+
   /**
    * Open "Add a Location" modal
    */
   function openAddLocationModal() {
-    Locations.modal()
-    .finally(function () {
-
-      // load countries again in case we added a country!
-      loadCountries();
-    });
+    Locations.modal();
   }
 }

--- a/client/src/partials/templates/modals/location.modal.html
+++ b/client/src/partials/templates/modals/location.modal.html
@@ -13,16 +13,14 @@
           class="btn btn-default"
           ng-class="{ 'active' : LocationModalCtrl.view.index === view.index }"
           ng-click="LocationModalCtrl.setView(view.cacheKey)"
-          data-location-view-key="{{ key }}"
-          >
+          data-location-view-key="{{ key }}">
           {{ view.translateKey | translate }}
         </button>
       </div>
     </div>
 
     <div class="form-group"
-      ng-class="{ 'has-error' : LocationModalForm.$submitted && LocationModalForm.country.$invalid }"
-      >
+      ng-class="{ 'has-error' : LocationModalForm.$submitted && LocationModalForm.country.$invalid }">
       <label class="control-label">
         {{ "FORM.LABELS.COUNTRY" | translate }}
       </label>
@@ -33,8 +31,7 @@
         ng-model="LocationModalCtrl.country"
         ng-change="LocationModalCtrl.loadProvinces()"
         ng-options="country as country.name for country in LocationModalCtrl.countries track by country.uuid"
-        required
-        >
+        required>
         <option value="" disabled>{{ LocationModalCtrl.messages.country | translate }}</option>
       </select>
       <input
@@ -48,8 +45,7 @@
 
     <div class="form-group"
       ng-class="{ 'has-error' : LocationModalForm.$submitted && LocationModalForm.province.$invalid }"
-      ng-if="LocationModalCtrl.view.index > 1"
-      >
+      ng-if="LocationModalCtrl.view.index > 1">
       <label class="control-label">
         {{ "FORM.LABELS.PROVINCE" | translate }}
       </label>
@@ -100,8 +96,7 @@
 
     <div class="form-group"
       ng-if="LocationModalCtrl.view.index > 3"
-      ng-class="{ 'has-error' : LocationModalForm.$submitted && LocationModalForm.village.$invalid }"
-      >
+      ng-class="{ 'has-error' : LocationModalForm.$submitted && LocationModalForm.village.$invalid }">
       <label class="control-label">
         {{ "FORM.LABELS.VILLAGE" | translate }}
       </label>

--- a/client/src/partials/templates/modals/location.modal.js
+++ b/client/src/partials/templates/modals/location.modal.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
 .controller('LocationModalController', LocationModalController);
 
 LocationModalController.$inject = [
-  'LocationService', '$uibModalInstance', 'appcache'
+  '$rootScope', 'LocationService', '$uibModalInstance', 'appcache'
 ];
 
 /**
@@ -15,7 +15,7 @@ LocationModalController.$inject = [
  *
  * @class LocationModalController
  */
-function LocationModalController(Locations, Instance, AppCache) {
+function LocationModalController($rootScope, Locations, Instance, AppCache) {
   var vm = this;
 
   /** caches the current view in local storage */
@@ -200,6 +200,8 @@ function LocationModalController(Locations, Instance, AppCache) {
     }
 
     return promise.then(function (data) {
+      // udpate all instances of bhLocationSelect
+      $rootScope.$broadcast('LOCATIONS_UPDATED', data);
       return Instance.close(data);
     })
     .catch(function (error) {


### PR DESCRIPTION
This commit introduces a method to refresh the data in the `bhLocationSelect`.
When locations are updated or added they broadcast an event on rootscope
and this is picked up by the component. This is a temporary fix and should
be redesigned with the proposed location changes.
