### PR TITLE
feature(locations): Location Merge Algorithm

### DIFF
--- a/server/models/procedures.sql
+++ b/server/models/procedures.sql
@@ -183,16 +183,16 @@ BEGIN
   -- populate core set-up values
   CALL PostingSetupUtil(date, enterprise_id, project_id, currency_id, current_fiscal_year_id, current_period_id, current_exchange_rate, enterprise_currency_id, transaction_id, gain_account_id, loss_account_id);
 
-  -- Check that all invoice items have sales accounts - if they do not the transaction will be imbalanced 
-  SELECT COUNT(invoice_item.uuid) 
+  -- Check that all invoice items have sales accounts - if they do not the transaction will be imbalanced
+  SELECT COUNT(invoice_item.uuid)
     INTO verify_invalid_accounts
   FROM invoice JOIN invoice_item JOIN inventory JOIN inventory_group
-  ON invoice.uuid = invoice_item.invoice_uuid 
-    AND invoice_item.inventory_uuid = inventory.uuid 
+  ON invoice.uuid = invoice_item.invoice_uuid
+    AND invoice_item.inventory_uuid = inventory.uuid
     AND inventory.group_uuid = inventory_group.uuid
   WHERE invoice.uuid = uuid
   AND inventory_group.sales_account IS NULL;
-  
+
   IF verify_invalid_accounts > 0 THEN
     SIGNAL InvalidSalesAccounts
     SET MESSAGE_TEXT = 'A NULL sales account has been found for an inventory item in this invoice.';
@@ -660,16 +660,16 @@ BEGIN
         the difference to the debtor and credit the difference as a gain to the gain_account
 
         - The debtor entity an invoice reference are not included on the gain
-          account transaction. In this case the debtor covered MORE than the 
-          invoiced amount and so referencing them on the enterprise gain will 
-          actually debit them the additional amount. 
+          account transaction. In this case the debtor covered MORE than the
+          invoiced amount and so referencing them on the enterprise gain will
+          actually debit them the additional amount.
       */
       IF (remainder > 0) THEN
-  
-        -- The debtor is not debited in this transaction. They have already 
-        -- balanced the invoice and their debt according to the invoice (the 
+
+        -- The debtor is not debited in this transaction. They have already
+        -- balanced the invoice and their debt according to the invoice (the
         -- exact amount). The additional payment can just be put in a gain account.
-        
+
         -- credit the rounding account
         INSERT INTO posting_journal (
           uuid, project_id, fiscal_year_id, period_id, trans_id, trans_date,
@@ -687,9 +687,9 @@ BEGIN
         A negative remainder means that the debtor underpaid slightly and we should credit
         the difference to the debtor and debit the difference as a loss to the loss_account
 
-        - The debtor and invoice are referenced on the loss account transaction 
-          make up for the amount that is loss. In this case the debtor has not 
-          actually paid enough money to cover the amount of the invoice. If this 
+        - The debtor and invoice are referenced on the loss account transaction
+          make up for the amount that is loss. In this case the debtor has not
+          actually paid enough money to cover the amount of the invoice. If this
           is not referenced his balance will not be zero.
       */
       ELSE
@@ -1143,6 +1143,29 @@ BEGIN
     ) AS zz;
 
   CALL PostVoucher(voucher_uuid);
+END $$
+
+
+-- this stored procedure merges two locations, deleting the first location_uuid after
+-- all locations have been migrated.
+CREATE PROCEDURE MergeLocations(
+  IN beforeUuid BINARY(16),
+  IN afterUuid BINARY(16)
+)
+BEGIN
+
+  -- Go through every location in the database, replacing the location uuid with the new location uuid
+  UPDATE patient SET origin_location_id = afterUuid WHERE origin_location_id = beforeUuid;
+  UPDATE patient SET current_location_id = afterUuid WHERE current_location_id = beforeUuid;
+
+  UPDATE debtor_group SET location_id = afterUuid WHERE location_id = beforeUuid;
+
+  UPDATE employee SET location_id = afterUuid WHERE location_id = beforeUuid;
+
+  UPDATE enterprise SET location_id = afterUuid WHERE location_id = beforeUuid;
+
+  -- delete the beforeUuid village and leave the afterUuid village.
+  DELETE FROM village WHERE village.uuid = beforeUuid;
 END $$
 
 DELIMITER ;


### PR DESCRIPTION
This commit implements the location merge algorithm requested from a
long time ago.  It loops through each table that uses a location
identifier and updates from one village UUID to another village UUID.
Once the process is complete, it deletes the freshly de-referenced UUID.

The client-side implementation has not been completed, but a system
administrator may find operation useful for data correction.

The algorithm is implemented as a stored procedure with the following
syntax:
```sql
-- both params are BINARY(16)
CALL MergeLocations(beforeUuid, afterUuid);
```


------
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
