### PR TITLE
feature(inventory): cache filter open/close state

### DIFF
--- a/client/src/partials/inventory/list/list.js
+++ b/client/src/partials/inventory/list/list.js
@@ -4,20 +4,22 @@ angular.module('bhima.controllers')
 // dependencies injection
 InventoryListController.$inject = [
   '$translate', 'InventoryService', 'NotifyService', 'uiGridConstants',
-  'ModalService', '$state', '$rootScope'
+  'ModalService', '$state', '$rootScope', 'appcache'
 ];
 
 /**
  * Inventory List Controllers
  * This controller is responsible of the inventory list module
  */
-function InventoryListController ($translate, Inventory, Notify, uiGridConstants, Modal, $state, $rootScope) {
+function InventoryListController ($translate, Inventory, Notify, uiGridConstants, Modal, $state, $rootScope, AppCache) {
   var vm = this;
 
   /** global variables */
   vm.filterEnabled = false;
   vm.gridOptions = {};
   vm.gridApi = {};
+
+  var cache = new AppCache('Inventory');
 
   vm.toggleFilter = toggleFilter;
 
@@ -73,7 +75,7 @@ function InventoryListController ($translate, Inventory, Notify, uiGridConstants
 
   /** enable filter */
   function toggleFilter() {
-    vm.filterEnabled = !vm.filterEnabled;
+    vm.filterEnabled = cache.filterEnabled = !vm.filterEnabled;
     vm.gridOptions.enableFiltering = vm.filterEnabled;
     vm.gridApi.core.notifyDataChange(uiGridConstants.dataChange.COLUMN);
   }
@@ -85,5 +87,9 @@ function InventoryListController ($translate, Inventory, Notify, uiGridConstants
         vm.gridOptions.data = inventory;
       })
       .catch(Notify.handleError);
+
+    // load the cached filter state
+    vm.filterEnabled = cache.filterEnabled || false;
+    vm.gridOptions.enableFiltering = vm.filterEnabled;
   }
 }


### PR DESCRIPTION
This commit ensures that the inventory list filter state is cached
between states.  This means that adding/editing items will not affect
the presence of the filter bar.  However, the filtered view is not cache.

----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
