### PR TITLE
(Feat.) Allow patient locations to be updated w/ edit module

### DIFF
--- a/client/src/partials/patients/edit/edit.html
+++ b/client/src/partials/patients/edit/edit.html
@@ -2,8 +2,8 @@
   <div class="bhima-title">
 
     <ol class="headercrumb">
-      <li class="static">{{ "TREE.HOSPITAL" | translate }}</li>
-      <li class="static">{{ "PATIENT_RECORDS.TITLE" | translate }}</li>
+      <li class="static"><span translate>TREE.HOSPITAL</span></li>
+      <li class="static"><span translate>PATIENT_RECORDS.TITLE</span></li>
       <li class="title">{{ PatientEditCtrl.medical.name }}</li>
     </ol>
 
@@ -212,6 +212,32 @@
                       {{ "FORM.LABELS.FEMALE" | translate }}
                     </label>
                   </div>
+                </div>
+
+                <hr>
+                <div class="form-group">
+                    <div class="col-md-5 col-md-offset-1">
+                      <h4><span translate>FORM.LABELS.ORIGIN_LOCATION</span></h4>
+                      <bh-location-select
+                        name="origin_location_id"
+                        id="origin-location-id"
+                        validation-trigger="patientDetails.$submitted"
+                        location-uuid="PatientEditCtrl.medical.origin_location_id">
+                      </bh-location-select>
+                    </div>
+
+                    <!-- separate location searches given a certain screen size -->
+                    <div class="visible-sm-block visible-xs-block"><hr></div>
+
+                    <div class="col-md-5 col-md-offset-1">
+                      <h4><span translate>FORM.LABELS.CURRENT_LOCATION</span></h4>
+                      <bh-location-select
+                        name="current_location_id"
+                        id="current-location-id"
+                        validation-trigger="patientDetails.$submitted"
+                        location-uuid="PatientEditCtrl.medical.current_location_id">
+                      </bh-location-select>
+                    </div>
                 </div>
               </div>
             </div>

--- a/client/src/partials/patients/edit/edit.js
+++ b/client/src/partials/patients/edit/edit.js
@@ -6,7 +6,7 @@ PatientEdit.$inject = [
   'ScrollService', 'PatientGroupModal', 'DateService', 'bhConstants'
 ];
 
-function PatientEdit($stateParams, patients, util, moment, Notify, ScrollTo, GroupModal, Dates, Constants) {
+function PatientEdit($stateParams, Patients, util, moment, Notify, ScrollTo, GroupModal, Dates, Constants) {
   var vm = this;
   var referenceId = $stateParams.uuid;
 
@@ -53,7 +53,7 @@ function PatientEdit($stateParams, patients, util, moment, Notify, ScrollTo, Gro
     // TODO Full patient/details object should be passed through find patient directive
     // 1. Only download id + name in patient directive
     // 2. Download full patients/details on selection
-    return patients.read(patientId)
+    return Patients.read(patientId)
       .then(function (patient) {
 
         formatPatientAttributes(patient);
@@ -73,7 +73,7 @@ function PatientEdit($stateParams, patients, util, moment, Notify, ScrollTo, Gro
   }
 
   function collectGroups(patientId) {
-    patients.groups(patientId)
+    Patients.groups(patientId)
       .then(function (result) {
         vm.finance = {patientGroups : result};
       });
@@ -109,7 +109,7 @@ function PatientEdit($stateParams, patients, util, moment, Notify, ScrollTo, Gro
 
     submitPatient = util.filterFormElements(patientDetailsForm, true);
 
-    return patients.update(vm.medical.uuid, submitPatient)
+    return Patients.update(vm.medical.uuid, submitPatient)
       .then(function (updatedPatient) {
         Notify.success('FORM.INFO.UPDATE_SUCCESS');
 

--- a/server/controllers/medical/patients/index.js
+++ b/server/controllers/medical/patients/index.js
@@ -231,7 +231,7 @@ function lookupPatient(patientUuid) {
 
   const sql = `
     SELECT BUID(p.uuid) as uuid, p.project_id, BUID(p.debtor_uuid) AS debtor_uuid, p.display_name, p.hospital_no,
-      p.sex, p.registration_date, p.email, p.phone, p.dob, BUID(p.origin_location_id) as origin_location_id,
+      p.sex, p.registration_date, p.email, p.phone, p.dob, BUID(p.origin_location_id) as origin_location_id, BUID(p.current_location_id) as current_location_id,
       CONCAT_WS('.', '${identifiers.PATIENT}', proj.abbr, p.reference) AS reference, p.title, p.address_1, p.address_2,
       p.father_name, p.mother_name, p.religion, p.marital_status, p.profession, p.employer, p.spouse,
       p.spouse_profession, p.spouse_employer, p.notes, p.avatar, proj.abbr, d.text,


### PR DESCRIPTION
This commit adds the origin and current location components
to the patient edit page.
* Syntax formatting on `Patient` service
* Add components into page
* Add `current_location_id` to server detailed request -
  addresses bug with this value missing.

Closes https://github.com/Vanga-Hospital/bhima-2.X/issues/62
