### PR TITLE
style(receipts): Use partial to underline POS receipts dynamically

### DIFF
--- a/server/controllers/finance/reports/cash/receipt.pos.handlebars
+++ b/server/controllers/finance/reports/cash/receipt.pos.handlebars
@@ -18,12 +18,12 @@
   {{payment.description}}
 </pre>
 
-<p>----------------------------------------------------------------</p>
+{{> underline}}
 {{#if hasRate}}
 <span>{{{translate 'EXCHANGE.INVOICE_DISCLAIMER'}}}</span>
 <br>
 <span>{{{translate 'EXCHANGE.SET_AS'}}} 1:{{rate}} {{{translate 'EXCHANGE.ON'}}} {{currentDateFormatted}}</span>
-<p>----------------------------------------------------------------</p>
+{{> underline}}
 {{/if}}
 
 {{#if payment.is_caution}}
@@ -63,7 +63,7 @@
     {{/if}}
   </tbody>
 </table>
-<p>----------------------------------------------------------------</p>
+{{> underline}}
 {{/each}}
 <!-- /if -->
 

--- a/server/controllers/finance/reports/invoices/receipt.pos.handlebars
+++ b/server/controllers/finance/reports/invoices/receipt.pos.handlebars
@@ -13,7 +13,7 @@
 
 <h2 style="margin-bottom : 0px">{{recipient.display_name}}</h2>
 ({{recipient.reference}}) - {{recipient.debtor_group_name}}
-<p>----------------------------------------------------------------</p>
+{{> underline}}
 <table style="width : 100%">
   <thead>
     <tr>
@@ -32,7 +32,7 @@
     {{/each}}
   </tbody>
 </table>
-<p>----------------------------------------------------------------</p>
+{{> underline}}
 <h2 style="text-align : right;">{{translate 'FORM.LABELS.TOTAL'}}: <b>{{currency cost metadata.enterprise.currency_id}}</b></h2>
 
 <!-- Bill exchange -->

--- a/server/controllers/medical/reports/patient.pos.handlebars
+++ b/server/controllers/medical/reports/patient.pos.handlebars
@@ -13,13 +13,13 @@
 
 <h2 style="margin-bottom : 0px">{{patient.display_name}}</h2>
 ({{patient.reference}}) - {{patient.debtor_group_name}}
-<p>----------------------------------------------------------------</p>
+{{> underline}}
 <p><u>{{translate "FORM.LABELS.DOB"}}</u>: {{date patient.dob }}</p>
 <p><u>{{translate "FORM.LABELS.HOSPITAL_FILE_NR"}}</u>: {{ patient.hospital_no }}</p>
 <p><u>{{translate "FORM.LABELS.GENDER"}}</u>: {{ patient.sex }}</p>
 <p><u>{{translate "TABLE.COLUMNS.REGISTERED_ON"}}</u>: {{date patient.registration_date }}</p>
 <p><u>{{translate "FORM.LABELS.DEBTOR_GROUP"}}</u>: {{ patient.debtor_group_name }}</p>
-<p>----------------------------------------------------------------</p>
+{{> underline}}
 
 <script>JsBarcode('.barcode').init();</script>
 </body>

--- a/server/lib/ReportManager.js
+++ b/server/lib/ReportManager.js
@@ -144,7 +144,7 @@ class ReportManager {
         let translatedName = translate(this.options.filename);
         let fileDate = (new Date()).toLocaleDateString();
         let formattedName = `${translatedName} ${fileDate}`;
-        renderHeaders['Content-Disposition'] = `attachment; filename=${formattedName}${renderer.extension}`;
+        renderHeaders['Content-Disposition'] = `filename=${formattedName}${renderer.extension}`;
       }
 
       // FIXME this branching logic should be promised based

--- a/server/lib/template/partials/underline.handlebars
+++ b/server/lib/template/partials/underline.handlebars
@@ -1,0 +1,1 @@
+<hr style="border : none; border-top : dashed 1px;" />


### PR DESCRIPTION
This commit uses a dashed <hr> tag to ensure that whatever specific wkhtmltopdf tweaks a machine/ OS
makes the underline on POS receipts will always be uniform. It also removes the `attachment`
attribute on the `Content-Dispositon` header set by ReportManager; this allows in browser debugging
of PDFs/ HTML.