### PR TITLE
fix(cash): sort registry amounts by number

### DIFF
--- a/client/src/partials/cash/payments/registry.js
+++ b/client/src/partials/cash/payments/registry.js
@@ -60,7 +60,7 @@ function CashPaymentRegistryController(Cash, bhConstants, Notify, Session, uiGri
     field : 'description', displayName : 'TABLE.COLUMNS.DESCRIPTION', headerCellFilter: 'translate'
   }, {
     field : 'amount', displayName : 'TABLE.COLUMNS.AMOUNT', headerCellFilter: 'translate',
-    cellTemplate : 'partials/cash/payments/templates/amount.grid.html',
+    cellTemplate : 'partials/cash/payments/templates/amount.grid.html', type: 'number',
 
     // @TODO(jniles): This is temporary, as it doesn't take into account USD payments
     aggregationType: uiGridConstants.aggregationTypes.sum, aggregationHideLabel : true,


### PR DESCRIPTION
This commit fixes a bug in the sorting algorithm of the amounts.  The
page now sorts amounts by number instead of text.

Closes #176.

-----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
