### PR TITLE
feat(filters) Filter invoices that have been reversed

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -868,7 +868,9 @@
   },
   "INVOICE_REGISTRY" : {
     "TITLE" : "Invoice Registry",
-    "RECEIPT_CURRENCY" : "Receipt Currency"
+    "RECEIPT_CURRENCY" : "Receipt Currency",
+    "EXCLUDE_REVERSE" : "Exclude all reversed invoices",
+    "INCLUDE_REVERSE" : "Include only reversed invoices"
   },
   "LOCATION": {
     "DESCRIPTION"           : "Location Manager Configuration is used to create location and to store it in the system, locations are very importants when you register a patient and so one. Use this module to",
@@ -964,7 +966,7 @@
       "REPORT_TITLE" : "Patient Checkin Report",
       "SUCCESS" : "Patient has been checked in"
     },
-    "VISITS" : { 
+    "VISITS" : {
       "TITLE" : "Patient Visits",
       "ADMIT" : "Admit Patient",
       "ADMISSION_DIAGNOSIS" : "Admission Diagnosis",

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -200,7 +200,7 @@
         "INFO"  : "Avec cette configuration, aucun membre de ce groupe débiteur ne sera subventionné",
         "LABEL"   : "Ce groupe est qualifié pour les subventions",
         "UPDATE"  : "Mettre à jour les subventions",
-        "EMPTY"   : "Ce groupe de débiteurs n'est pas souscrit à des subventions"        
+        "EMPTY"   : "Ce groupe de débiteurs n'est pas souscrit à des subventions"
       },
       "DISCOUNTS" : {
         "TITLE" : "Réductions",
@@ -220,7 +220,7 @@
     "SUBSCRIPTIONS"  : "Abonnements",
     "UPDATED"        : "Enregistrement du groupe débiteur mis à jour"
   },
-  "DOWNLOADS" : { 
+  "DOWNLOADS" : {
     "JSON" : "Télécharger en JSON",
     "PDF" : "Télécharger en PDF",
     "CSV" : "Télécharger en CSV"
@@ -521,7 +521,7 @@
       "END"                    : "Fin",
       "END_DATE"               : "Date de fin",
       "ENTER_BIRTH_YEAR"       : "Entrez seulement l'année de naissance",
-      "ENTER_BIRTH_DAY"        : "Entrez la date de naissance complète",      
+      "ENTER_BIRTH_DAY"        : "Entrez la date de naissance complète",
       "ENTERPRISE"             : "Entreprise",
       "ENTERPRISE_ID"          : "ID entreprise",
       "ENTITY"                 : "Entité",
@@ -851,7 +851,7 @@
     "SYSTEM"         : "Hospital Management System",
     "TITLE"          : "Bhima",
     "TODAY"          : "Date du jour",
-    "DEBTORS" : { 
+    "DEBTORS" : {
       "TITLE"    : "Debiteurs de l'entreprise",
       "BALANCED" : "Toutes les dettes sont reglées",
       "CACHED"   : "Données à jour"
@@ -880,7 +880,9 @@
   },
   "INVOICE_REGISTRY" : {
     "TITLE" : "Registre des Factures",
-    "RECEIPT_CURRENCY" : "Monnaie du reçu"
+    "RECEIPT_CURRENCY" : "Monnaie du reçu",
+    "EXCLUDE_REVERSE" : "Exclure toutes les factures inversees",
+    "INCLUDE_REVERSE" : "Inclure uniquement les factures inversees"
   },
   "LOCATION": {
     "DESCRIPTION"           : "La gestion des Localisation est utilisée pour créer des Localisations, La localisation est tres important quand vous créez un patient et ainsi de suite. Utiliser Ce module pour",
@@ -973,7 +975,7 @@
       "BY" : "par",
       "SUCCESS" : "Confirmation de la visite du patient avec succes"
     },
-    "VISITS" : { 
+    "VISITS" : {
       "TITLE" : "Visites des patients",
       "ADMIT" : "Admission à l'hôpital",
       "ADMISSION_DIAGNOSIS" : "Diagnostic Admission",

--- a/client/src/js/services/PatientInvoiceService.js
+++ b/client/src/js/services/PatientInvoiceService.js
@@ -123,6 +123,7 @@ function PatientInvoiceService(Modal, util, Session, Api) {
       { field: 'billingDateFrom', displayName: 'FORM.LABELS.DATE', comparitor: '>', ngFilter:'date' },
       { field: 'billingDateTo', displayName: 'FORM.LABELS.DATE', comparitor: '<', ngFilter:'date' },
       { field: 'patientNames', displayName : 'FORM.LABELS.PATIENT_NAME'},
+      { field: 'reversed', displayName : 'FORM.INFO.CREDIT_NOTE' }
     ];
 
     // returns columns from filters

--- a/client/src/partials/patient_invoice/registry/search.modal.html
+++ b/client/src/partials/patient_invoice/registry/search.modal.html
@@ -45,6 +45,29 @@
         </div>
       </div>
 
+      <div class="form-group">
+        <label class="control-label"><span translate>FORM.INFO.CREDIT_NOTE</span></label>
+        <span style="display:inline-block;" class="pull-right">
+          <a href ng-click="ModalCtrl.clear('reversed')" tabindex="-1">
+            <i class="fa fa-eraser"></i> <span translate>FORM.BUTTONS.CLEAR</span>
+          </a>
+        </span>
+
+        <div class="radio">
+          <label>
+            <input type="radio" name="optionsReversal" value="0" ng-model="ModalCtrl.params.reversed">
+            <span translate>INVOICE_REGISTRY.EXCLUDE_REVERSE</span>
+          </label>
+        </div>
+
+        <div class="radio">
+          <label>
+            <input type="radio" name="optionsReversal" value="1" ng-model="ModalCtrl.params.reversed">
+            <span translate>INVOICE_REGISTRY.INCLUDE_REVERSE</span>
+          </label>
+        </div>
+      </div>
+
       <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.service.$invalid }">
         <label class="control-label">{{ 'FORM.LABELS.SERVICE' | translate }}</label>
         <span style="display:inline-block;" class="pull-right">

--- a/server/controllers/finance/patientInvoice.js
+++ b/server/controllers/finance/patientInvoice.js
@@ -267,6 +267,28 @@ function find(options) {
     delete options.user_id;
   }
 
+  if (options.reversed) {
+    // @TODO All constant definitions for types on the server should be centralised
+    const CREDIT_NOTE_VOUCHER_ID = 10;
+    let includeCreditNotes = Boolean(Number(options.reversed));
+
+    if (includeCreditNotes) {
+      // only return invoices that have been reversed
+      conditions.statements.push(`voucher.type_id = ?`);
+
+    } else {
+      // only return invoices that have not been reversed
+      // NULL type id means no vouchers reference this invoice
+      conditions.statements.push(`voucher.type_id IS NULL OR voucher.type_id <> ?`);
+    }
+
+    // using the reversal voucher id as the parameter is a hack, this will be
+    // addressed in standardising filters on the server and the client
+    conditions.parameters.push(CREDIT_NOTE_VOUCHER_ID);
+
+    delete options.reversed;
+  }
+
 
   sql += conditions.statements.join(' AND ');
   if (conditions.statements.length && !_.isEmpty(options)) { sql += ' AND '; }


### PR DESCRIPTION
This commit adds a new filter to the invoice registry, allowing invoices
to be filtered on their reversal status. It provides the option of
exclusively seeing reversed invoices, exluding all reversed invoices or
seeing both (by simply removing the filter).

![screenshot 2017-01-25 at 10 22 10](https://cloud.githubusercontent.com/assets/2844572/22284604/5e562036-e2e8-11e6-8feb-d246b2b96ec3.png)
*Filter option in search modal*

Contributes to https://github.com/Vanga-Hospital/bhima-2.X/issues/19
Provides features to help resolve https://github.com/Vanga-Hospital/bhima-2.X/issues/139. This can be closed if this works for users.


