### PR TITLE
feat(csv) Implement basic default CSV filters

### DIFF
--- a/server/lib/renderers/csv.js
+++ b/server/lib/renderers/csv.js
@@ -16,6 +16,12 @@
 const q = require('q');
 const _ = require('lodash');
 const converter = require('json-2-csv');
+const moment = require('moment');
+
+// @TODO Discuss if this should be moved into its own library
+const DATE_FORMAT = 'DD/MM/YYYY';
+const SUPPRESS_DEFAULT_FORMATTING = false;
+const SUPPRESS_DEFAULT_FILTERING = false;
 
 const headers = {
   'Content-Type' : 'text/csv'
@@ -48,7 +54,19 @@ function renderCSV(data, template, options) {
   // allow different server routes to pass in csvOptions
   const csvOptions = _.defaults(options.csvOptions, defaults);
 
-  const csvData = data[options.csvKey || DEFAULT_DATA_KEY];
+  let csvData = data[options.csvKey || DEFAULT_DATA_KEY];
+
+  if (!SUPPRESS_DEFAULT_FORMATTING) {
+    csvData = csvData.map(dateFormatter);
+  }
+
+  if (!SUPPRESS_DEFAULT_FILTERING) {
+    // row based filters
+    csvData = csvData.map(idFilter);
+
+    // data set based filters
+    csvData = emptyFilter(csvData);
+  }
 
   // render the data array csv as needed
   converter.json2csv(csvData, (error, csv) => {
@@ -58,4 +76,64 @@ function renderCSV(data, template, options) {
 
   // return the promise
   return dfd.promise;
+}
+
+
+/**
+ * @method dateFormatter
+ *
+ * @description
+ * Accepts an object of key/value pairs. Returns the same object with all values
+ * that are dates converted to a standard format.
+ */
+function dateFormatter(csvRow) {
+  // utility function that accepts the value of a CSV date column and converts to a standard format
+  const convertIfDate = (csvValue, csvColumn) => _.isDate(csvValue) ? moment(csvValue).format(DATE_FORMAT) : csvValue;
+  return _.mapValues(csvRow, convertIfDate);
+}
+
+/**
+ * @method idFilter
+ *
+ * @description
+ * Accepts an object of key/ value pairs. Returns a manipulated object, removing
+ * all columns that match a pre-defined list of keywords
+ */
+function idFilter(csvRow) {
+  const ID_KEYWORDS = ['_id', 'uuid'];
+  const invalidColumns = _.keys(csvRow).filter(containsIdKeyword);
+
+  function containsIdKeyword(columnName) {
+    return ID_KEYWORDS.some((keyword) => columnName.includes(keyword));
+  }
+
+  invalidColumns.forEach((columnName) => delete csvRow[columnName]);
+  return csvRow;
+}
+
+/**
+ * @method emptyFilter
+ *
+ * @description
+ * Accepts an array of CSV object rows. This method removes attributes from each
+ * row if that attribute is NULL for every value in the array.
+ */
+function emptyFilter(csvData) {
+  if (_.isEmpty(csvData)) { return []; }
+
+  const firstElement = csvData[0];
+
+  // assumes all rows have exactly the same columns
+  const invalidColumns = _.keys(firstElement).filter(columnIsEmpty);
+
+  function columnIsEmpty(columnName) {
+    // this will return true as soon as any of the values in the rows are not NULL
+    // if it returns true we return false (!true) to ensure this row is kept
+    return !csvData.some((csvRow) => !_.isNil(csvRow[columnName]));
+  }
+
+  return csvData.map((csvRow) => {
+    invalidColumns.forEach((columnName) => delete csvRow[columnName]);
+    return csvRow;
+  });
 }


### PR DESCRIPTION
This commit introduces the idea of CSV filters (described in #161). It introduces two types
of basic filters that can be suppressed with a given flag.

Three rules have been implemented by default 
`dateFormatter` - Ensure all dates are formatted 'DD/MM/YYYY'
`idFilter` - Reject all columns with either '_id' or 'uuid' in the column name 
`emptyFilter` - Reject all columns that have `NULL` values for every row in the data set

---

*Patient registry with filters suppressed*
![screenshot 2017-01-25 at 13 05 46](https://cloud.githubusercontent.com/assets/2844572/22290450/1ca1f070-e301-11e6-98de-fea6b0aff0e5.png)
**Number of columns : 39**
**Dates formatted with default .toString()**
**UUIDs presented to user**

*Patient registry with filters enabled*
![screenshot 2017-01-25 at 13 04 17](https://cloud.githubusercontent.com/assets/2844572/22290479/4e0d4952-e301-11e6-922c-bbd7e03c7577.png)
**Number of columns : 16**
**Dates formatted with rule 'DD/MM/YYYY'**
**UUIDs not presented to user**

Closes https://github.com/Vanga-Hospital/bhima-2.X/issues/161.