### PR TITLE
fix(trial_balance) use POST for large params

### DIFF
--- a/client/src/js/services/TrialBalanceService.js
+++ b/client/src/js/services/TrialBalanceService.js
@@ -38,7 +38,7 @@ function TrialBalanceService(util, $http, $translate) {
 
     return list;
   }
- 
+
   function  getCSSClass (feedBack) {
     return feedBack.hasError ? 'grid-error' : feedBack.hasWarning ? 'grid-warning' : 'grid-success';
   }
@@ -111,8 +111,8 @@ function TrialBalanceService(util, $http, $translate) {
     var url = baseUrl.concat('data_per_account/');
     var transactions = getTransactionList(lines);
 
-    /** Querying the database to get the data grouped per account**/    
-    return $http.get(url, { params : {transactions : transactions}})
+    /** Querying the database to get the data grouped per account**/
+    return $http.post(url, { transactions : transactions })
       .then(util.unwrapHttpResponse);
   }
 

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -219,7 +219,7 @@ exports.configure = function configure(app) {
   app.get('/general_ledger', generalLedger.list);
 
   //API for trial balance
-  app.get('/trial_balance/data_per_account', trialBalance.getDataPerAccount);
+  app.post('/trial_balance/data_per_account', trialBalance.getDataPerAccount);
   app.post('/trial_balance/checks', trialBalance.checkTransactions);
   app.post('/trial_balance/post_transactions', trialBalance.postToGeneralLedger);
 

--- a/test/integration/trialBalance.js
+++ b/test/integration/trialBalance.js
@@ -26,8 +26,8 @@ describe('(/trial) API endpoint', function () {
   const NUM_ROWS_UNKNOWN_TRANSACTIONS = 0;
 
   it('GET /trial_balance/data_per_account : it returns data grouped by account ', function () {
-    return agent.get('/trial_balance/data_per_account')
-      .query(transactionParameter.goodTransaction.params)
+    return agent.post('/trial_balance/data_per_account')
+      .send(transactionParameter.goodTransaction.params)
       .then(function (res) {
         helpers.api.listed(res, NUM_ROWS_GOOD_TRANSACTION);
       })
@@ -35,8 +35,8 @@ describe('(/trial) API endpoint', function () {
   });
 
   it('GET /trial_balance/data_per_account : it returns an empty array when there is no transaction matching ', function () {
-    return agent.get('/trial_balance/data_per_account')
-      .query(transactionParameter.unknownTransactions.params)
+    return agent.post('/trial_balance/data_per_account')
+      .send(transactionParameter.unknownTransactions.params)
       .then(function (res) {
         helpers.api.listed(res, NUM_ROWS_UNKNOWN_TRANSACTIONS);
       })
@@ -44,8 +44,8 @@ describe('(/trial) API endpoint', function () {
   });
 
   it('GET /trial_balance/data_per_account : it returns an error message and 400 code if the request parameter is null or undefined ', function () {
-    return agent.get('/trial_balance/data_per_account')
-      .query(transactionParameter.emptyParam.params)
+    return agent.post('/trial_balance/data_per_account')
+      .send(transactionParameter.emptyParam.params)
       .then(function (res) {
         helpers.api.errored(res, 400);
       })
@@ -55,7 +55,7 @@ describe('(/trial) API endpoint', function () {
   it('POST /trial_balance/checks : it returns an array of object containing one warning object', function () {
     return agent.post('/trial_balance/checks')
       .send(transactionParameter.warningTransaction.params)
-      .then(function (res) {        
+      .then(function (res) {
         expect(res).to.have.status(201);
         expect(res).to.be.json;
         expect(res.body).to.not.be.empty;
@@ -77,7 +77,7 @@ describe('(/trial) API endpoint', function () {
       })
       .catch(helpers.handler);
   });
-  
+
   it('POST /trial_balance/post_transactions : it posts the a transaction to general_ledger and remove it form the posting_general', function () {
     return agent.post('/trial_balance/post_transactions')
       .send(transactionParameter.postingTransaction.params)


### PR DESCRIPTION
This commit ensures that a `POST` request is used for all of the trial
balance methods. `GET` requests with paremeters passed in the query
resulted in server errors from attempting to process very long query
strings.

This commit also udpates the trial balance controller to bring it more
in line with the style of the current repository. Favouring tested
library methods over custom utilities and using more up to date ES6
syntax.

Closes https://github.com/Vanga-Hospital/bhima-2.X/issues/166